### PR TITLE
Fix for Bazel incompatible changes

### DIFF
--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -24,13 +24,11 @@ _perl_deps_attr = attr.label_list(
 )
 
 _perl_data_attr = attr.label_list(
-    cfg = "data",
     allow_files = True,
 )
 
 _perl_main_attr = attr.label(
-    allow_files = _perl_file_types,
-    single_file = True,
+    allow_single_file = _perl_file_types,
 )
 
 _perl_env_attr = attr.string_dict()
@@ -158,7 +156,7 @@ def _perl_binary_implementation(ctx):
     if main == None:
         main = _get_main_from_sources(ctx)
 
-    ctx.file_action(
+    ctx.actions.write(
         output = ctx.outputs.executable,
         content = _create_stub(
             ctx.workspace_name,
@@ -167,7 +165,7 @@ def _perl_binary_implementation(ctx):
             ctx.attr.env,
             ctx.attr.env_files,
         ),
-        executable = True,
+        is_executable = True,
     )
 
     return struct(

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -14,7 +14,7 @@
 
 """Perl rules for Bazel"""
 
-_perl_file_types = FileType([".pl", ".pm", ".t"])
+_perl_file_types = [".pl", ".pm", ".t"]
 
 _perl_srcs_attr = attr.label_list(allow_files = _perl_file_types)
 
@@ -38,11 +38,11 @@ def _collect_transitive_sources(ctx):
     for dep in ctx.attr.deps:
         result += dep.transitive_perl_sources
 
-    result += _perl_file_types.filter(ctx.files.srcs)
+    result += ctx.files.srcs
     return result
 
 def _get_main_from_sources(ctx):
-    sources = _perl_file_types.filter(ctx.files.srcs)
+    sources = ctx.files.srcs
     if len(sources) != 1:
         fail("Cannot infer main from multiple 'srcs'. Please specify 'main' attribute.", "main")
     return sources[0]

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -34,12 +34,11 @@ _perl_main_attr = attr.label(
 _perl_env_attr = attr.string_dict()
 
 def _collect_transitive_sources(ctx):
-    result = depset(order = "postorder")
-    for dep in ctx.attr.deps:
-        result += dep.transitive_perl_sources
-
-    result += ctx.files.srcs
-    return result
+    return depset(
+        ctx.files.srcs,
+        transitive = [dep.transitive_perl_sources for dep in ctx.attr.deps],
+        order = "postorder",
+    )
 
 def _get_main_from_sources(ctx):
     sources = ctx.files.srcs
@@ -173,7 +172,7 @@ def _perl_binary_implementation(ctx):
         runfiles = ctx.runfiles(
             collect_data = True,
             collect_default = True,
-            transitive_files = transitive_sources + [ctx.outputs.executable],
+            transitive_files = depset([ctx.outputs.executable], transitive = [transitive_sources]),
         ),
     )
 

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -63,7 +63,7 @@ def _is_identifier(name):
         return False
 
     # Must consist of alnum characters or '_'s.
-    for c in name:
+    for c in name.elems():
         if not (c.isalnum() or c == "_"):
             return False
     return True
@@ -167,9 +167,9 @@ def _perl_binary_implementation(ctx):
         is_executable = True,
     )
 
-    return struct(
+    return DefaultInfo(
         files = depset([ctx.outputs.executable]),
-        runfiles = ctx.runfiles(
+        default_runfiles = ctx.runfiles(
             collect_data = True,
             collect_default = True,
             transitive_files = depset([ctx.outputs.executable], transitive = [transitive_sources]),


### PR DESCRIPTION
- reformat bzl file
- remove deprecated API
- use modern providers
- avoid string/depset iteration

Tested:
  `bazel20 test //... --all_incompatible_changes --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false`

Remaining issues are inside Bazel, as far as I know.