### PR TITLE
replace continue with next

### DIFF
--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -95,7 +95,7 @@ sub main {{
     if (-l $stub_filename) {{
       # Absolutize
       $stub_filename = catfile(dirname($stub_filename), readlink $stub_filename);
-      continue;
+      next;
     }}
 
     if ($0 =~ /(.*\\.runfiles)/.*/) {{


### PR DESCRIPTION
Perl's construct for the traditional 'continue' statement in other
languages is 'next'.