### PR TITLE
Fix path to the executable in "perl_binary".

### DIFF
--- a/perl/binary_wrapper.tpl
+++ b/perl/binary_wrapper.tpl
@@ -11,4 +11,4 @@ else
   exit 1
 fi
 
-{env_vars} $PATH_PREFIX{interpreter} -I${PATH_PREFIX} {main} "$@"
+{env_vars} $PATH_PREFIX{interpreter} -I${PATH_PREFIX} ${PATH_PREFIX}{main} "$@"


### PR DESCRIPTION
This allows using "perl_binary" in "genrule" targets.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>