### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,16 +1,16 @@
 ---
 platforms:
-  ubuntu1604:
+  ubuntu1804:
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   macos:
     build_targets:
-    - "..."
+    - "//..."
     - "-//examples/cpan:IOTty"
     - "-//examples/cpan:IOTtyXS"
     - "-//examples/external_module:complex_deps"
     test_targets:
-    - "..."
+    - "//..."
     - "-//examples/external_module:complex_deps"


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.