### PR TITLE
fix issue where rules_perl could not used for cross compilation

### DIFF
--- a/perl/private/BUILD.dist.bazel.tpl
+++ b/perl/private/BUILD.dist.bazel.tpl
@@ -25,9 +25,6 @@ toolchain(
     exec_compatible_with = [
         {exec_constraints},
     ],
-    target_compatible_with = [
-        {target_constraints},
-    ],
     toolchain = ":toolchain_impl",
     toolchain_type = "@rules_perl//:toolchain_type",
 )

--- a/perl/repo.bzl
+++ b/perl/repo.bzl
@@ -25,7 +25,6 @@ def _perl_download_impl(ctx):
 
     substitutions = {
         "{exec_constraints}": constraint_str,
-        "{target_constraints}": constraint_str,
     }
     ctx.template(
         "BUILD.bazel",


### PR DESCRIPTION
When using the perl toolchain and specifying a platform on the bazel
command line (e.g. --platforms=:android), the command would fail as
bazel required a perl toolchain that is "target compatible" with the
":android" platform. Unlike a C++ toolchain, the perl toolchain is
compatible with any target platform therefore no `target_compatible_with` should be specified