### PR TITLE
Provide Strawberry Perl toolchain for Windows (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Modules that require compiling are not yet supported.
 
 ## Windows Support
 
-No Windows Support yet.  Maybe something for Strawberry Perl someday.
+This repository provides a hermetic [Strawberry Perl](https://strawberryperl.com/) bazel toolchain for Windows. Usage of the toolchain in `perl_` rules is not yet supported.
 
 ## Using Perl Modules
 

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -26,9 +26,22 @@ def perl_register_toolchains():
         ]
     )
 
+    perl_download(
+        name = "perl_windows_amd64",
+        arch = "amd64",
+        os = "windows",
+        strip_prefix = "",
+        sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
+        urls = [
+            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+            "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+        ],
+    )    
+
     native.register_toolchains(
         "@perl_darwin_amd64//:toolchain",
         "@perl_linux_amd64//:toolchain",
+        "@perl_windows_amd64//:toolchain",
     )
 
 def perl_rules_dependencies():

--- a/perl/repo.bzl
+++ b/perl/repo.bzl
@@ -12,6 +12,8 @@ def _perl_download_impl(ctx):
         os_constraint = "@platforms//os:osx"
     elif ctx.attr.os == "linux":
         os_constraint = "@platforms//os:linux"
+    elif ctx.attr.os == "windows":
+        os_constraint = "@platforms//os:windows"
     else:
         fail("Unsupported OS: " + ctx.attr.os)
 
@@ -46,7 +48,7 @@ perl_download = repository_rule(
         ),
         "os": attr.string(
             mandatory = True,
-            values = ["darwin", "linux"],
+            values = ["darwin", "linux", "windows"],
             doc = "Host operating system for the Perl distribution",
         ),
         "arch": attr.string(

--- a/perl/toolchain.bzl
+++ b/perl/toolchain.bzl
@@ -20,7 +20,7 @@ PerlRuntimeInfo = provider(
 def _find_tool(ctx, name):
     cmd = None
     for f in ctx.files.runtime:
-        if f.path.endswith("/bin/%s" % name) or f.path.endswith("/bin/%s.exe" % name):
+        if f.path.endswith("/bin/%s" % name) or f.path.endswith("/bin/%s.exe" % name) or f.path.endswith("/bin/%s.bat" % name):
             cmd = f
             break
     if not cmd:


### PR DESCRIPTION
This toolchain can be used to build OpenSSL for Windows under Bazel.