### PR TITLE
Fetch only required perl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,3 +4,12 @@ load("@rules_perl//perl:deps.bzl", "perl_register_toolchains", "perl_rules_depen
 
 perl_rules_dependencies()
 perl_register_toolchains()
+
+# The following invocation of register_toolchains shouldn't be required as the toolchains should be registered in 
+# perl_register_toolchains but for some reason the invocation of native.register_toolchains in perl_register_toolchains()
+# doesn't seem to work unless called from a workspace other than rules_perl
+register_toolchains(
+    "@rules_perl//:darwin_toolchain",
+    "@rules_perl//:linux_toolchain",
+    "@rules_perl//:windows_toolchain"
+)

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -6,8 +6,6 @@ perl_download = _perl_download
 def perl_register_toolchains():
     perl_download(
         name = "perl_linux_amd64",
-        arch = "amd64",
-        os = "linux",
         strip_prefix = "perl-x86_64-linux",
         sha256 = "2cea6d78bf29c96450a70729e94ae2ef877dbc590fdaf3ef8dad74f7fae0d7de",
         urls = [
@@ -17,8 +15,6 @@ def perl_register_toolchains():
 
     perl_download(
         name = "perl_darwin_amd64",
-        arch = "amd64",
-        os = "darwin",
         strip_prefix = "perl-darwin-2level",
         sha256 = "9ede6e5200d2b69524ed8074edbcddf8c4c3e8f67a756edce133cabaa4ad2347",
         urls = [
@@ -28,8 +24,6 @@ def perl_register_toolchains():
 
     perl_download(
         name = "perl_windows_amd64",
-        arch = "amd64",
-        os = "windows",
         strip_prefix = "",
         sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
         urls = [
@@ -39,9 +33,9 @@ def perl_register_toolchains():
     )    
 
     native.register_toolchains(
-        "@perl_darwin_amd64//:toolchain",
-        "@perl_linux_amd64//:toolchain",
-        "@perl_windows_amd64//:toolchain",
+        "@rules_perl//:darwin_toolchain",
+        "@rules_perl//:linux_toolchain",
+        "@rules_perl//:windows_toolchain"
     )
 
 def perl_rules_dependencies():

--- a/perl/private/BUILD.dist.bazel.tpl
+++ b/perl/private/BUILD.dist.bazel.tpl
@@ -1,30 +1,10 @@
 # This template is used by perl_download to generate a build file for
 # a downloaded Perl distribution.
 
-load("@rules_perl//perl:toolchain.bzl", "perl_toolchain")
 package(default_visibility = ["//visibility:public"])
 
 # tools contains executable files that are part of the toolchain.
 filegroup(
     name = "runtime",
     srcs = glob(["**/*"]),
-)
-
-# toolchain_impl gathers information about the Perl toolchain.
-# See the PerlToolchain provider.
-perl_toolchain(
-    name = "toolchain_impl",
-    runtime = [":runtime"],
-)
-
-# toolchain is a Bazel toolchain that expresses execution and target
-# constraints for toolchain_impl. This target should be registered by
-# calling register_toolchains in a WORKSPACE file.
-toolchain(
-    name = "toolchain",
-    exec_compatible_with = [
-        {exec_constraints},
-    ],
-    toolchain = ":toolchain_impl",
-    toolchain_type = "@rules_perl//:toolchain_type",
 )

--- a/perl/repo.bzl
+++ b/perl/repo.bzl
@@ -8,30 +8,9 @@ def _perl_download_impl(ctx):
     )
 
     ctx.report_progress("Creating Perl toolchain files")
-    if ctx.attr.os == "darwin":
-        os_constraint = "@platforms//os:osx"
-    elif ctx.attr.os == "linux":
-        os_constraint = "@platforms//os:linux"
-    elif ctx.attr.os == "windows":
-        os_constraint = "@platforms//os:windows"
-    else:
-        fail("Unsupported OS: " + ctx.attr.os)
-
-    if ctx.attr.arch == "amd64":
-        arch_constraint = "@platforms//cpu:x86_64"
-    else:
-        fail("Unsupported arch: " + ctx.attr.arch)
-
-    constraints = [os_constraint, arch_constraint]
-    constraint_str = ",\n        ".join(['"%s"' % c for c in constraints])
-
-    substitutions = {
-        "{exec_constraints}": constraint_str,
-    }
     ctx.template(
         "BUILD.bazel",
         ctx.attr._build_tpl,
-        substitutions = substitutions,
     )
 
 perl_download = repository_rule(
@@ -44,16 +23,6 @@ perl_download = repository_rule(
         "sha256": attr.string(
             mandatory = True,
             doc = "Expected SHA-256 sum of the downloaded archive",
-        ),
-        "os": attr.string(
-            mandatory = True,
-            values = ["darwin", "linux", "windows"],
-            doc = "Host operating system for the Perl distribution",
-        ),
-        "arch": attr.string(
-            mandatory = True,
-            values = ["amd64"],
-            doc = "Host architecture for the Perl distribution",
         ),
         # TODO - This only works for perl from a download
         # perl built in a tree or system perl would hate this


### PR DESCRIPTION
Previously, the darwin, linux and windows variants of perl would be downloaded even if only one of them were required.
Now, only the required toolchains are downloaded.