### PR TITLE
Allow Perl source with no file extension

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,3 +24,14 @@ http_archive(
     strip_prefix = "FCGI-0.79",
     url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/FCGI-0.79.tar.gz",
 )
+
+# genhtml can be used to generate HTML reports from the output of the bazel
+# coverage command. It also serves as a natural test case for Perl scripts with
+# no file extension.
+http_archive(
+    name = "genhtml",
+    build_file = "//:examples/genhtml/genhtml.BUILD",
+    sha256 = "d88b0718f59815862785ac379aed56974b9edd8037567347ae70081cd4a3542a",
+    strip_prefix = "lcov-1.15/bin",
+    url = "https://github.com/linux-test-project/lcov/archive/refs/tags/v1.15.tar.gz",
+)

--- a/examples/genhtml/BUILD
+++ b/examples/genhtml/BUILD
@@ -1,0 +1,26 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_perl//perl:perl.bzl", "perl_test")
+
+perl_test(
+    name = "genhtml_test",
+    srcs = ["genhtml_test.t"],
+    data = [
+        "coverage.dat",
+        "genhtml_test.t",
+        "@genhtml//:genhtml_bin",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/genhtml/coverage.dat
+++ b/examples/genhtml/coverage.dat
@@ -1,0 +1,11 @@
+SF:examples/genhtml/genhtml_test.t
+FNF:0
+FNH:0
+BRDA:20,1,1,1
+BRF:1
+BRH:1
+DA:20,1
+DA:21,1
+LH:2
+LF:2
+end_of_record

--- a/examples/genhtml/genhtml.BUILD
+++ b/examples/genhtml/genhtml.BUILD
@@ -1,0 +1,22 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_perl//perl:perl.bzl", "perl_binary")
+
+perl_binary(
+    name = "genhtml_bin",
+    srcs = ["genhtml"],
+    data = ["get_version.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/genhtml/genhtml_test.t
+++ b/examples/genhtml/genhtml_test.t
@@ -1,0 +1,22 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+`../genhtml/genhtml_bin -o $ENV{TEST_UNDECLARED_OUTPUTS_DIR} examples/genhtml/coverage.dat`;
+ok(-e "$ENV{TEST_UNDECLARED_OUTPUTS_DIR}/index.html", 'genhtml generated index.html');
+

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -34,7 +34,7 @@ PERL_XS_COPTS = [
     "-D_FILE_OFFSET_BITS=64",
 ]
 
-_perl_file_types = [".pl", ".pm", ".t", ".so", ".ix", ".al"]
+_perl_file_types = [".pl", ".pm", ".t", ".so", ".ix", ".al", ""]
 _perl_srcs_attr = attr.label_list(allow_files = _perl_file_types)
 
 _perl_deps_attr = attr.label_list(


### PR DESCRIPTION
Perl source files without a file extension are relatively common ([genhtml](https://github.com/linux-test-project/lcov/blob/master/bin/genhtml) is an example).