### PR TITLE
Adjust rules_perl to work with darwin amd64 and arm architectures

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,23 +24,40 @@ toolchain_type(
         toolchain(
             name = "{os}_toolchain".format(os = os),
             exec_compatible_with = [
-                "@platforms//os:{os}".format(os = os if os != "darwin" else "osx"),
+                "@platforms//os:{os}".format(os = os),
                 "@platforms//cpu:x86_64",
             ],
             target_compatible_with = [
-                "@platforms//os:{os}".format(os = os if os != "darwin" else "osx"),
+                "@platforms//os:{os}".format(os = os),
                 "@platforms//cpu:x86_64",
             ],
-            toolchain = "{os}_toolchain_impl".format(os = os),
+            toolchain = ":{os}_toolchain_impl".format(os = os),
             toolchain_type = ":toolchain_type",
         ),
     )
     for os in [
-        "darwin",
         "linux",
         "windows",
     ]
 ]
+
+# "darwin" is special; the toolchain is a fat binary with both amd64 and arm64.
+perl_toolchain(
+    name = "darwin_toolchain_impl",
+    runtime = ["@perl_darwin_2level//:runtime"],
+)
+
+toolchain(
+    name = "darwin_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:osx",
+    ],
+    target_compatible_with = [
+        "@platforms//os:osx",
+    ],
+    toolchain = ":darwin_toolchain_impl",
+    toolchain_type = ":toolchain_type",
+)
 
 # This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
 # other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -17,7 +17,7 @@ def perl_register_toolchains():
     )
 
     perl_download(
-        name = "perl_darwin_amd64",
+        name = "perl_darwin_2level",
         strip_prefix = "perl-darwin-2level",
         sha256 = "9ede6e5200d2b69524ed8074edbcddf8c4c3e8f67a756edce133cabaa4ad2347",
         urls = [


### PR DESCRIPTION
The relocatable perl binary distribution distributes "fat" darwin
binaries that are capable of working on both architectures, so adjust
the build rules so that it works.

Now on an M1 mac you can do this:

cd examples/hello_world
bazel run :hello_world

Changes from: https://github.com/bazelbuild/rules_perl/pull/38