### PR TITLE
fix: remove target_compatible_with

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,10 +27,6 @@ toolchain_type(
                 "@platforms//os:{os}".format(os = os if os != "darwin" else "osx"),
                 "@platforms//cpu:x86_64",
             ],
-            target_compatible_with = [
-                "@platforms//os:{os}".format(os = os if os != "darwin" else "osx"),
-                "@platforms//cpu:x86_64",
-            ],
             toolchain = "{os}_toolchain_impl".format(os = os),
             toolchain_type = ":toolchain_type",
         ),


### PR DESCRIPTION
See https://github.com/bazel-contrib/rules-template/pull/9.

I hit this while cross-compiling C++ code that transiently required perl for building.