### PR TITLE
Remove target_compatible_with on osx

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -48,9 +48,6 @@ toolchain(
     exec_compatible_with = [
         "@platforms//os:osx",
     ],
-    target_compatible_with = [
-        "@platforms//os:osx",
-    ],
     toolchain = ":darwin_toolchain_impl",
     toolchain_type = ":toolchain_type",
 )


### PR DESCRIPTION
I see that this was missed in PR #44

I haven't encountered any errors related to it, but it seems like removing it from osx would also be the correct move.