### PR TITLE
Upgrade to relocatable-perl 5.36.0.1

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
-load("@rules_perl//perl:toolchain.bzl", "current_perl_toolchain", "perl_toolchain")
 load("@rules_perl//:platforms.bzl", "platforms")
+load("@rules_perl//perl:toolchain.bzl", "current_perl_toolchain", "perl_toolchain")
 
 # toolchain_type defines a name for a kind of toolchain. Our toolchains
 # declare that they have this type. Our rules request a toolchain of this type.

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 load("@rules_perl//perl:toolchain.bzl", "current_perl_toolchain", "perl_toolchain")
+load("@rules_perl//:platforms.bzl", "platforms")
 
 # toolchain_type defines a name for a kind of toolchain. Our toolchains
 # declare that they have this type. Our rules request a toolchain of this type.
@@ -14,13 +15,13 @@ toolchain_type(
         # toolchain_impl gathers information about the Perl toolchain.
         # See the PerlToolchain provider.
         perl_toolchain(
-            name = "{os}_{cpu}_toolchain_impl".format(
-                cpu = cpu,
-                os = os,
+            name = "perl_{os}_{cpu}_toolchain_impl".format(
+                cpu = platform.cpu,
+                os = platform.os,
             ),
             runtime = ["@perl_{os}_{cpu}//:runtime".format(
-                cpu = cpu,
-                os = os,
+                cpu = platform.cpu,
+                os = platform.os,
             )],
         ),
 
@@ -28,47 +29,25 @@ toolchain_type(
         # constraints for toolchain_impl. This target should be registered by
         # calling register_toolchains in a WORKSPACE file.
         toolchain(
-            name = "{os}_{cpu}_toolchain".format(
-                cpu = cpu,
-                os = os,
+            name = "perl_{os}_{cpu}_toolchain".format(
+                cpu = platform.cpu,
+                os = platform.os,
             ),
-            exec_compatible_with = [
-                "@platforms//os:{os}".format(os = os),
-                "@platforms//cpu:{cpu}".format(cpu = cpu),
-            ],
-            toolchain = ":{os}_{cpu}_toolchain_impl".format(
-                cpu = cpu,
-                os = os,
+            exec_compatible_with = platform.exec_compatible_with,
+            toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
+                cpu = platform.cpu,
+                os = platform.os,
             ),
             toolchain_type = ":toolchain_type",
         ),
     )
-    for os, cpu in [
-        ("linux", "arm64"),
-        ("linux", "x86_64"),
-        ("windows", "x86_64"),
-    ]
+    for platform in platforms
 ]
-
-# "darwin" is special; the toolchain is a fat binary with both amd64 and arm64.
-perl_toolchain(
-    name = "darwin_toolchain_impl",
-    runtime = ["@perl_darwin_2level//:runtime"],
-)
-
-toolchain(
-    name = "darwin_toolchain",
-    exec_compatible_with = [
-        "@platforms//os:osx",
-    ],
-    toolchain = ":darwin_toolchain_impl",
-    toolchain_type = ":toolchain_type",
-)
 
 # This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
 # other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has
 # happened, to a rule which expects a concrete implementation of a toolchain, rather than a
-# toochain_type which could be resolved to that toolchain.
+# toolchain_type which could be resolved to that toolchain.
 #
 # See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
 current_perl_toolchain(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,22 +1,27 @@
 workspace(name = "rules_perl")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_perl//perl:deps.bzl", "perl_register_toolchains", "perl_rules_dependencies")
+load("//:platforms.bzl", "platforms")
 
 perl_rules_dependencies()
 
 perl_register_toolchains()
 
-# The following invocation of register_toolchains shouldn't be required as the toolchains should be registered in
-# perl_register_toolchains but for some reason the invocation of native.register_toolchains in perl_register_toolchains()
-# doesn't seem to work unless called from a workspace other than rules_perl
-register_toolchains(
-    "@rules_perl//:darwin_toolchain",
-    "@rules_perl//:linux_arm64_toolchain",
-    "@rules_perl//:linux_x86_64_toolchain",
-    "@rules_perl//:windows_x86_64_toolchain",
-)
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+# The following invocation of register_toolchains shouldn't be required as the
+# toolchains should be registered in perl_register_toolchains but for some
+# reason the invocation of native.register_toolchains in
+# perl_register_toolchains() doesn't seem to work unless called from a workspace
+# other than rules_perl.
+[
+    register_toolchains(
+        "@rules_perl//:perl_{os}_{cpu}_toolchain".format(
+            cpu = platform.cpu,
+            os = platform.os,
+        ),
+    )
+    for platform in platforms
+]
 
 http_archive(
     name = "fcgi",

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -2,55 +2,23 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//perl:repo.bzl", _perl_download = "perl_download")
+load("//:platforms.bzl", "platforms")
 
 perl_download = _perl_download
 
 # buildifier: disable=unnamed-macro
 def perl_register_toolchains():
     """Register the relocatable perl toolchains."""
-    perl_download(
-        name = "perl_linux_arm64",
-        strip_prefix = "perl-aarch64-linux",
-        sha256 = "01af07bc84fc9c162b09eda880f5868b67ccb440071f8088e5278e1ae394aefd",
-        urls = [
-            "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.0/perl-aarch64-linux.tar.xz",
-        ],
-    )
-
-    perl_download(
-        name = "perl_linux_x86_64",
-        strip_prefix = "perl-x86_64-linux",
-        sha256 = "77ee5dfec156bd8135be3c2e9b295a393c7f7a0c7999b8932ff83ed938f65d02",
-        urls = [
-            "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.0/perl-x86_64-linux.tar.xz",
-        ],
-    )
-
-    perl_download(
-        name = "perl_darwin_2level",
-        strip_prefix = "perl-darwin-2level",
-        sha256 = "7c2e739c9da246f22e94a394cdc9d6817eba2c15c3db7aaca60b3c8cd5fe6611",
-        urls = [
-            "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.0/perl-darwin-2level.tar.xz",
-        ],
-    )
-
-    perl_download(
-        name = "perl_windows_x86_64",
-        strip_prefix = "",
-        sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
-        urls = [
-            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
-            "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
-        ],
-    )
-
-    native.register_toolchains(
-        "@rules_perl//:darwin_toolchain",
-        "@rules_perl//:linux_arm64_toolchain",
-        "@rules_perl//:linux_x86_64_toolchain",
-        "@rules_perl//:windows_x86_64_toolchain",
-    )
+    for platform in platforms:
+        perl_download(
+            name = "perl_%s_%s" % (platform.os, platform.cpu),
+            strip_prefix = platform.strip_prefix,
+            sha256 = platform.sha256,
+            urls = platform.urls,
+        )
+        native.register_toolchains(
+            "@rules_perl//:perl_{os}_{cpu}_toolchain".format(os = platform.os, cpu = platform.cpu),
+        )
 
 def perl_rules_dependencies():
     """Declares external repositories that rules_go_simple depends on.

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -1,8 +1,8 @@
 """Perl rules dependencies"""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//perl:repo.bzl", _perl_download = "perl_download")
 load("//:platforms.bzl", "platforms")
+load("//perl:repo.bzl", _perl_download = "perl_download")
 
 perl_download = _perl_download
 

--- a/platforms.bzl
+++ b/platforms.bzl
@@ -21,7 +21,6 @@ platforms = [
         strip_prefix = "perl-darwin-arm64",
         exec_compatible_with = [
             "@platforms//os:osx",
-            "@platforms//cpu:arm64",
         ],
     ),
     struct(

--- a/platforms.bzl
+++ b/platforms.bzl
@@ -4,10 +4,10 @@
 platforms = [
     struct(
         os = "darwin",
-        cpu = "amd64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-amd64.tar.xz"],
-        sha256 = "63bc5ee36f5394d71c50cca6cafdd333ee58f9eaa40bca63c85f9bd06f2c1fd6",
-        strip_prefix = "perl-darwin-amd64",
+        cpu = "arm64",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-arm64.tar.xz"],
+        sha256 = "285769f3c50c339fb59a3987b216ae3c5c573b95babe6875a1ef56fb178433da",
+        strip_prefix = "perl-darwin-arm64",
         exec_compatible_with = [
             "@platforms//os:osx",
             "@platforms//cpu:aarch64",
@@ -15,12 +15,13 @@ platforms = [
     ),
     struct(
         os = "darwin",
-        cpu = "arm64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-arm64.tar.xz"],
-        sha256 = "285769f3c50c339fb59a3987b216ae3c5c573b95babe6875a1ef56fb178433da",
-        strip_prefix = "perl-darwin-arm64",
+        cpu = "amd64",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-amd64.tar.xz"],
+        sha256 = "63bc5ee36f5394d71c50cca6cafdd333ee58f9eaa40bca63c85f9bd06f2c1fd6",
+        strip_prefix = "perl-darwin-amd64",
         exec_compatible_with = [
             "@platforms//os:osx",
+            "@platforms//cpu:x86_64",
         ],
     ),
     struct(

--- a/platforms.bzl
+++ b/platforms.bzl
@@ -1,0 +1,63 @@
+"""platforms.bzl defines metadata about the different relocatable-perl versions
+"""
+
+platforms = [
+    struct(
+        os = "darwin",
+        cpu = "amd64",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-amd64.tar.xz"],
+        sha256 = "63bc5ee36f5394d71c50cca6cafdd333ee58f9eaa40bca63c85f9bd06f2c1fd6",
+        strip_prefix = "perl-darwin-amd64",
+        exec_compatible_with = [
+            "@platforms//os:osx",
+            "@platforms//cpu:aarch64",
+        ],
+    ),
+    struct(
+        os = "darwin",
+        cpu = "arm64",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-arm64.tar.xz"],
+        sha256 = "285769f3c50c339fb59a3987b216ae3c5c573b95babe6875a1ef56fb178433da",
+        strip_prefix = "perl-darwin-arm64",
+        exec_compatible_with = [
+            "@platforms//os:osx",
+            "@platforms//cpu:arm64",
+        ],
+    ),
+    struct(
+        os = "linux",
+        cpu = "amd64",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-amd64.tar.xz"],
+        sha256 = "3bdffa9d7a3f97c0207314637b260ba5115b1d0829f97e3e2e301191a4d4d076",
+        strip_prefix = "perl-linux-amd64",
+        exec_compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:x86_64",
+        ],
+    ),
+    struct(
+        os = "linux",
+        cpu = "arm64",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-arm64.tar.xz"],
+        sha256 = "6fa4ece99e790ecbc2861f6ecb7b52694c01c2eeb215b4370f16a3b12d952117",
+        strip_prefix = "perl-linux-arm64",
+        exec_compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:arm64",
+        ],
+    ),
+    struct(
+        os = "windows",
+        cpu = "x86_64",
+        urls = [
+            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+            "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+        ],
+        sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
+        strip_prefix = "",
+        exec_compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:x86_64",
+        ],
+    ),
+]


### PR DESCRIPTION
I'm new to rules_perl (wanted to try it for genhtml), but couldn't use on my M1 mac.  Given #52 was outstanding issue, went ahead and added this.

Newest release of [relocatable-perl 5.36.0.1]() has a much more consistent asset naming convention, so I went ahead and simplified the toolchain naming / setup. 