### PR TITLE
Enable bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,10 @@
 Perl rules
 """
 
-module(name = "rules_perl", version = "0.1.0")
+module(
+    name = "rules_perl",
+    version = "0.1.0",
+)
 
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
@@ -10,8 +13,8 @@ bazel_dep(name = "bazel_skylib", version = "1.4.2")
 repos = use_extension("@rules_perl//perl:extensions.bzl", "perl_repositories")
 use_repo(
     repos,
-    "perl_darwin_arm64",
     "perl_darwin_amd64",
+    "perl_darwin_arm64",
     "perl_linux_amd64",
     "perl_linux_arm64",
     "perl_windows_x86_64",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,26 @@
+"""
+Perl rules
+"""
+
+module(name = "rules_perl", version = "0.1.0")
+
+bazel_dep(name = "platforms", version = "0.0.6")
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
+
+repos = use_extension("@rules_perl//perl:extensions.bzl", "perl_repositories")
+use_repo(
+    repos,
+    "perl_darwin_arm64",
+    "perl_darwin_amd64",
+    "perl_linux_amd64",
+    "perl_linux_arm64",
+    "perl_windows_x86_64",
+)
+
+register_toolchains(
+    "@rules_perl//:perl_darwin_arm64_toolchain",
+    "@rules_perl//:perl_darwin_amd64_toolchain",
+    "@rules_perl//:perl_linux_amd64_toolchain",
+    "@rules_perl//:perl_linux_arm64_toolchain",
+    "@rules_perl//:perl_windows_x86_64_toolchain",
+)

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -7,8 +7,7 @@ load("//perl:repo.bzl", _perl_download = "perl_download")
 perl_download = _perl_download
 
 # buildifier: disable=unnamed-macro
-def perl_register_toolchains():
-    """Register the relocatable perl toolchains."""
+def perl_repos():
     for platform in platforms:
         perl_download(
             name = "perl_%s_%s" % (platform.os, platform.cpu),
@@ -16,6 +15,13 @@ def perl_register_toolchains():
             sha256 = platform.sha256,
             urls = platform.urls,
         )
+
+# buildifier: disable=unnamed-macro
+def perl_register_toolchains():
+    """Register the relocatable perl toolchains."""
+    perl_repos()
+
+    for platform in platforms:
         native.register_toolchains(
             "@rules_perl//:perl_{os}_{cpu}_toolchain".format(os = platform.os, cpu = platform.cpu),
         )

--- a/perl/extensions.bzl
+++ b/perl/extensions.bzl
@@ -1,0 +1,10 @@
+"""Entry point for extensions used by bzlmod."""
+
+load("@rules_perl//perl:deps.bzl", "perl_repos")
+
+def _perl_repositories(_module_ctx):
+    perl_repos()
+
+perl_repositories = module_extension(
+    implementation = _perl_repositories,
+)


### PR DESCRIPTION
Adds files to make it possible to use ``rules_perl`` using bzlmod.

This can be used in a ``MODULES.bazel`` using a snippet like:

```
bazel_dep(name = "rules_python", version = "0.1.0")

archive_override(
    module_name = "rules_perl",
    urls = [
        "https://github.com/bazelbuild/rules_perl/archive/76bc70ef16b4bab2d6c9cd5ea387405e6b3bee6a.tar.gz",
    ],
    strip_prefix = "rules_perl-76bc70ef16b4bab2d6c9cd5ea387405e6b3bee6a",
    integrity = "sha256-uHDm8XnLUKTMzaXykUAth63MrG3xhG77FhtYcANCrI0=",
)
```

Note: The ``archive_override`` can be removed if you also start publishing releases to registry.bazel.build.