### PR TITLE
Add a dependency for `rules_cc` to `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "rules_cc", version = "0.0.8")
 
 repos = use_extension("@rules_perl//perl:extensions.bzl", "perl_repositories")
 use_repo(


### PR DESCRIPTION
`rules_perl` requires the `rules_cc` repository to be present: https://github.com/bazelbuild/rules_perl/blob/022b8daf2bb4836ac7a50e4a1d8ea056a3e1e403/perl/perl.bzl#L19

While this isn't an issue when running the examples for this repo (i.e. `bazel build --enable_bzlmod //examples/hello_world:hello_world` works fine — rules_cc appears to be implicitly added to the repo mapping for the current root module's repo), when depending on `rules_perl` from another module this becomes an issue.

Even if the dependent pulls in the `rules_cc` module, `rules_cc` will not be visible in `rules_perl`'s mapping unless `rules_perl` also declares a dependency on it.