### PR TITLE
Fix windows path incompatibility

### DIFF
--- a/perl/toolchain.bzl
+++ b/perl/toolchain.bzl
@@ -40,6 +40,10 @@ def _perl_toolchain_impl(ctx):
     xsubpp_cmd = _find_tool(ctx, "xsubpp")
     xs_headers = _find_xs_headers(ctx)
 
+    interpreter_cmd_path = interpreter_cmd.path
+    if ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]):
+        interpreter_cmd_path = interpreter_cmd.path.replace("/", "\\")
+
     return [
         platform_common.ToolchainInfo(
             name = ctx.label.name,
@@ -51,7 +55,7 @@ def _perl_toolchain_impl(ctx):
                 perlopt = ctx.attr.perlopt,
             ),
             make_variables = platform_common.TemplateVariableInfo({
-                "PERL": interpreter_cmd.path,
+                "PERL": interpreter_cmd_path,
             }),
         ),
     ]
@@ -67,6 +71,7 @@ perl_toolchain = rule(
             allow_files = True,
             cfg = "target",
         ),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     },
     doc = "Gathers functions and file lists needed for a Perl toolchain",
 )


### PR DESCRIPTION
When using rules_perl with nmake on windows, the exported path to PERL has `/` instead of `\`. This causes nmake targets to break.

For example when nmake need to execute a target that needs to run:

```
C:\users\jsun\_bazel_jsun\2pzzqzw2\execroot\splcore\external/perl_windows_x86_64/perl/bin/perl.exe util/mkdir-p.pl
```

It returns the error
```
'C:\users\jsun\_bazel_jsun\2pzzqzw2\execroot\splcore\external' is not recognized as an internal or external command,
operable program or batch file.
NMAKE : fatal error U1077: 'C:\users\jsun\_bazel_jsun\2pzzqzw2\execroot\splcore\external' : return code '0x1'
Stop.
```

This PR fixes this by checking for the appropriate windows platform constraint and replacing the path separator as needed. The method is documented [here](https://github.com/bazelbuild/proposals/blob/main/designs/2019-11-11-target-platform-constraints.md#proposal-a-check-method-that-takes-a-constraint-value-label)
