### PR TITLE
Moved targets into `//perl` package and aliased original locations

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,56 +1,16 @@
-load("@rules_perl//:platforms.bzl", "platforms")
-load("@rules_perl//perl:toolchain.bzl", "current_perl_toolchain", "perl_toolchain")
-
-# toolchain_type defines a name for a kind of toolchain. Our toolchains
-# declare that they have this type. Our rules request a toolchain of this type.
-# Bazel selects a toolchain of the correct type that satisfies platform
-# constraints from among registered toolchains.
-toolchain_type(
-    name = "toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
 [
-    (
-        # toolchain_impl gathers information about the Perl toolchain.
-        # See the PerlToolchain provider.
-        perl_toolchain(
-            name = "perl_{os}_{cpu}_toolchain_impl".format(
-                cpu = platform.cpu,
-                os = platform.os,
-            ),
-            runtime = ["@perl_{os}_{cpu}//:runtime".format(
-                cpu = platform.cpu,
-                os = platform.os,
-            )],
-        ),
-
-        # toolchain is a Bazel toolchain that expresses execution and target
-        # constraints for toolchain_impl. This target should be registered by
-        # calling register_toolchains in a WORKSPACE file.
-        toolchain(
-            name = "perl_{os}_{cpu}_toolchain".format(
-                cpu = platform.cpu,
-                os = platform.os,
-            ),
-            exec_compatible_with = platform.exec_compatible_with,
-            toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
-                cpu = platform.cpu,
-                os = platform.os,
-            ),
-            toolchain_type = ":toolchain_type",
-        ),
+    alias(
+        name = name,
+        actual = "//perl:{}".format(name),
+        visibility = ["//visibility:public"],
     )
-    for platform in platforms
+    for name in [
+        "current_toolchain",
+        "perl_darwin_amd64_toolchain",
+        "perl_darwin_arm64_toolchain",
+        "perl_linux_amd64_toolchain",
+        "perl_linux_arm64_toolchain",
+        "perl_windows_x86_64_toolchain",
+        "toolchain_type",
+    ]
 ]
-
-# This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
-# other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has
-# happened, to a rule which expects a concrete implementation of a toolchain, rather than a
-# toolchain_type which could be resolved to that toolchain.
-#
-# See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
-current_perl_toolchain(
-    name = "current_toolchain",
-    visibility = ["//visibility:public"],
-)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,9 +22,9 @@ use_repo(
 )
 
 register_toolchains(
-    "@rules_perl//:perl_darwin_arm64_toolchain",
-    "@rules_perl//:perl_darwin_amd64_toolchain",
-    "@rules_perl//:perl_linux_amd64_toolchain",
-    "@rules_perl//:perl_linux_arm64_toolchain",
-    "@rules_perl//:perl_windows_x86_64_toolchain",
+    "@rules_perl//perl:perl_darwin_arm64_toolchain",
+    "@rules_perl//perl:perl_darwin_amd64_toolchain",
+    "@rules_perl//perl:perl_linux_amd64_toolchain",
+    "@rules_perl//perl:perl_linux_arm64_toolchain",
+    "@rules_perl//perl:perl_windows_x86_64_toolchain",
 )

--- a/perl/BUILD
+++ b/perl/BUILD
@@ -1,1 +1,60 @@
+load("//:platforms.bzl", "platforms")
+load(":toolchain.bzl", "current_perl_toolchain", "perl_toolchain")
+
 exports_files(["binary_wrapper.tpl"])
+
+# toolchain_type defines a name for a kind of toolchain. Our toolchains
+# declare that they have this type. Our rules request a toolchain of this type.
+# Bazel selects a toolchain of the correct type that satisfies platform
+# constraints from among registered toolchains.
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+[
+    (
+        # toolchain_impl gathers information about the Perl toolchain.
+        # See the PerlToolchain provider.
+        perl_toolchain(
+            name = "perl_{os}_{cpu}_toolchain_impl".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            ),
+            runtime = ["@perl_{os}_{cpu}//:runtime".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            )],
+            visibility = ["//visibility:public"],
+        ),
+
+        # toolchain is a Bazel toolchain that expresses execution and target
+        # constraints for toolchain_impl. This target should be registered by
+        # calling register_toolchains in a WORKSPACE file.
+        toolchain(
+            name = "perl_{os}_{cpu}_toolchain".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            ),
+            exec_compatible_with = platform.exec_compatible_with,
+            toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            ),
+            toolchain_type = ":toolchain_type",
+            visibility = ["//visibility:public"],
+        ),
+    )
+    for platform in platforms
+]
+
+# This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
+# other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has
+# happened, to a rule which expects a concrete implementation of a toolchain, rather than a
+# toolchain_type which could be resolved to that toolchain.
+#
+# See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
+current_perl_toolchain(
+    name = "current_toolchain",
+    visibility = ["//visibility:public"],
+)

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -23,14 +23,17 @@ def perl_register_toolchains():
 
     for platform in platforms:
         native.register_toolchains(
-            "@rules_perl//:perl_{os}_{cpu}_toolchain".format(os = platform.os, cpu = platform.cpu),
+            "@rules_perl//perl:perl_{os}_{cpu}_toolchain".format(
+                os = platform.os,
+                cpu = platform.cpu,
+            ),
         )
 
 def perl_rules_dependencies():
-    """Declares external repositories that rules_go_simple depends on.
+    """Declares external repositories that rules_perl depends on.
 
     This function should be loaded and called from WORKSPACE of any project
-    that uses rules_go_simple.
+    that uses rules_perl.
     """
 
     # bazel_skylib is a set of libraries that are useful for writing

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -111,7 +111,7 @@ def _perl_library_implementation(ctx):
     ]
 
 def _perl_binary_implementation(ctx):
-    toolchain = ctx.toolchains["@rules_perl//:toolchain_type"].perl_runtime
+    toolchain = ctx.toolchains["@rules_perl//perl:toolchain_type"].perl_runtime
     interpreter = toolchain.interpreter
 
     transitive_sources = transitive_deps(ctx, extra_files = toolchain.runtime + [ctx.outputs.executable])
@@ -218,7 +218,7 @@ def _perl_xs_cc_lib(ctx, toolchain, srcs):
     )
 
 def _perl_xs_implementation(ctx):
-    toolchain = ctx.toolchains["@rules_perl//:toolchain_type"].perl_runtime
+    toolchain = ctx.toolchains["@rules_perl//perl:toolchain_type"].perl_runtime
     xsubpp = toolchain.xsubpp
 
     toolchain_files = depset(toolchain.runtime)
@@ -274,7 +274,7 @@ perl_library = rule(
         "srcs": _perl_srcs_attr,
     },
     implementation = _perl_library_implementation,
-    toolchains = ["@rules_perl//:toolchain_type"],
+    toolchains = ["@rules_perl//perl:toolchain_type"],
 )
 
 perl_binary = rule(
@@ -291,7 +291,7 @@ perl_binary = rule(
     },
     executable = True,
     implementation = _perl_binary_implementation,
-    toolchains = ["@rules_perl//:toolchain_type"],
+    toolchains = ["@rules_perl//perl:toolchain_type"],
 )
 
 perl_test = rule(
@@ -309,7 +309,7 @@ perl_test = rule(
     executable = True,
     test = True,
     implementation = _perl_test_implementation,
-    toolchains = ["@rules_perl//:toolchain_type"],
+    toolchains = ["@rules_perl//perl:toolchain_type"],
 )
 
 perl_xs = rule(
@@ -328,7 +328,7 @@ perl_xs = rule(
     implementation = _perl_xs_implementation,
     fragments = ["cpp"],
     toolchains = [
-        "@rules_perl//:toolchain_type",
+        "@rules_perl//perl:toolchain_type",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
 )

--- a/perl/toolchain.bzl
+++ b/perl/toolchain.bzl
@@ -77,7 +77,7 @@ perl_toolchain = rule(
 )
 
 def _current_perl_toolchain_impl(ctx):
-    toolchain = ctx.toolchains["@rules_perl//:toolchain_type"]
+    toolchain = ctx.toolchains["@rules_perl//perl:toolchain_type"]
 
     return [
         toolchain,
@@ -98,5 +98,5 @@ def _current_perl_toolchain_impl(ctx):
 # See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
 current_perl_toolchain = rule(
     implementation = _current_perl_toolchain_impl,
-    toolchains = ["@rules_perl//:toolchain_type"],
+    toolchains = ["@rules_perl//perl:toolchain_type"],
 )


### PR DESCRIPTION
It's more common for `bazelbuild` rules repos to have targets in the rules package. This change updates `rules_perl` to meet that expectation so developers introducing the rules to their repo have a slightly easier time.

Aliases have been added to avoid a backwards incompatible change.