### PR TITLE
Makes rules_perl work with `--experimental_sibling_repository_layout`.

### DIFF
--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -231,7 +231,9 @@ def _perl_xs_implementation(ctx):
         args_typemaps += ["-typemap", typemap.short_path]
 
     for src in ctx.files.srcs:
-        out = ctx.actions.declare_file(paths.replace_extension(src.path, ".c"))
+        c_execpath = paths.replace_extension(src.path, ".c")
+        o_packagepath = paths.join("_objs/execroot/", c_execpath)
+        out = ctx.actions.declare_file(o_packagepath)
 
         ctx.actions.run(
             outputs = [out],


### PR DESCRIPTION
The reason it did not work was that the code assumed that the execpath of any artifact can be passed to `ctx.actions.declare_file()`, but that's not the case for artifacts not in the main repository when sibling repository layout is in effect: their paths start with `../` which would make them ascend above the package directory.

This also triggered a bug in Bazel
(https://github.com/bazelbuild/bazel/issues/22362), but even if that bug didn't exist, this would still not work.

Serendipitously, the principled fix for
`--experimental_sibling_repository_layout` is also a workaround for the above bug. It adds two path segments to the package-relative path of the .o file, akin to how c++ rules work.