### PR TITLE
Add `includes` attr to automate `$PERL5LIB`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,9 @@ Now you can specify it as a dependency to any script that requires that module:
 ```
 
 **NOTE**: at this time you need to provide the directory that Perl needs to add to @INC.
+
+### Automatic PERL5LIB
+
+`perl_binary` (and `perl_test`) sets up the `PERL5LIB` environment variable with values for `perl_library` dependencies.
+By default this will be each perl_library's "lib" directory if present in source paths, otherwise the package dir.
+You can override this with the `perl5lib_paths` attribute.

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ Now you can specify it as a dependency to any script that requires that module:
 
 **NOTE**: at this time you need to provide the directory that Perl needs to add to @INC.
 
-### Automatic PERL5LIB
+### PERL5LIB includes
 
-`perl_binary` (and `perl_test`) sets up the `PERL5LIB` environment variable with values for `perl_library` dependencies.
-By default this will be each perl_library's "lib" directory if present in source paths, otherwise the package dir.
-You can override this with the `perl5lib_paths` attribute.
+`perl_binary` (and `perl_test`) sets up the `PERL5LIB` environment variable with values for all `perl_library` dep's `includes`.
+The default includes are `[".", "lib"]`.

--- a/examples/cpan/BUILD
+++ b/examples/cpan/BUILD
@@ -20,6 +20,7 @@ package(default_visibility = ["//visibility:public"])
 perl_library(
     name = "TestMockSimple",
     srcs = ["Test-Mock-Simple-0.10/lib/Test/Mock/Simple.pm"],
+    includes = ["Test-Mock-Simple-0.10/lib"],
 )
 
 # Better example of module placement with dependence

--- a/examples/cpan/BUILD
+++ b/examples/cpan/BUILD
@@ -49,7 +49,7 @@ perl_xs(
     name = "IOTtyXS",
     srcs = ["auto/IO/Tty/Tty.xs"],
     defines = [
-        "HAVE_DEV_PTMX",
+        # "HAVE_DEV_PTMX",
         "HAVE_GETPT",
         "HAVE_GRANTPT",
         "HAVE_POSIX_OPENPT",

--- a/examples/cpan_remote/BUILD
+++ b/examples/cpan_remote/BUILD
@@ -19,8 +19,5 @@ package(default_visibility = ["//visibility:public"])
 perl_test(
     name = "fcgi_import_test",
     srcs = ["fcgi_import_test.t"],
-    env = {
-        "PERL5LIB": "../fcgi/lib:../fcgi/arch",
-    },
     deps = ["@fcgi//:FCGI"],
 )

--- a/examples/cpan_remote/fcgi.BUILD
+++ b/examples/cpan_remote/fcgi.BUILD
@@ -20,7 +20,7 @@ perl_library(
         "lib/FCGI.pm",
         ":FCGIXS",
     ],
-    perl5lib_paths = [
+    includes = [
         "arch",
         "lib",
     ],

--- a/examples/cpan_remote/fcgi.BUILD
+++ b/examples/cpan_remote/fcgi.BUILD
@@ -20,6 +20,10 @@ perl_library(
         "lib/FCGI.pm",
         ":FCGIXS",
     ],
+    perl5lib_paths = [
+        "arch",
+        "lib",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/examples/external_module/BUILD
+++ b/examples/external_module/BUILD
@@ -22,17 +22,11 @@ package(default_visibility = ["//visibility:public"])
 perl_test(
     name = "pure_perl",
     srcs = ["pure_perl.t"],
-    env = {
-        "PERL5LIB": "examples/cpan/Test-Mock-Simple-0.10/lib",
-    },
     deps = ["//examples/cpan:TestMockSimple"],
 )
 
 perl_test(
     name = "complex_deps",
     srcs = ["complex_deps.t"],
-    env = {
-        "PERL5LIB": "examples/cpan",
-    },
     deps = ["//examples/cpan:IOTty"],
 )

--- a/perl/binary_wrapper.tpl
+++ b/perl/binary_wrapper.tpl
@@ -11,4 +11,6 @@ else
   exit 1
 fi
 
+export PERL5LIB="$PERL5LIB{PERL5LIB}"
+
 {env_vars} $PATH_PREFIX{interpreter} -I${PATH_PREFIX} ${PATH_PREFIX}{main} "$@"

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -124,7 +124,10 @@ def _perl5lib_paths(ctx):
         if not libdir_for_src:
             libdir_for_src = (ctx.label.workspace_root or ".") + "/" + ctx.label.package
         perl5lib_paths.append(libdir_for_src)
-    return depset(direct = perl5lib_paths).to_list()
+    for dep in ctx.attr.deps:
+        perl5lib_paths.extend(dep[PerlLibrary].perl5lib_paths)
+    perl5lib_paths = depset(direct = perl5lib_paths).to_list()
+    return perl5lib_paths
 
 def _perl_library_implementation(ctx):
     transitive_sources = transitive_deps(ctx)

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -23,6 +23,7 @@ PerlLibrary = provider(
     doc = "A provider containing components of a `perl_library`",
     fields = [
         "transitive_perl_sources",
+        "perl5lib_paths",
     ],
 )
 
@@ -99,6 +100,32 @@ def transitive_deps(ctx, extra_files = [], extra_deps = []):
         files = files,
     )
 
+def _perl5lib_paths(ctx):
+    """Calculate the PERL5LIB paths for a perl_library rule's srcs.
+
+    Examples for perl5lib_paths ["lib"] (=default) (srcs -> perl5lib_paths):
+    * ["lib/Foo/Bar.pm", "lib/Foo/lib/Baz.pm"] -> ["lib"]
+    * ["Module-1.0/lib/Foo/Bar.pm"] -> ["Module-1.0/lib"]
+    * ["src/Foo.pm","Bar.pm"] -> ["."]
+    * ["src/Foo.pm","bar/lib/Bar.pm"] -> [".", "bar/lib"]
+    * ["@cpan_foo"] -> ["external/cpan_foo"] (WORKSPACE)
+    * ["@cpan_foo"] -> ["external/lcov~~_repo_rules~cpan_foo"] (Bzlmod)
+    * ["@cpan_foo//:lib/Foo.pm"] -> ["external/cpan_foo/lib"] (WORKSPACE)
+    * ["@cpan_foo//:lib/Foo.pm"] -> ["external/lcov~~_repo_rules~cpan_foo/lib"] (Bzlmod)
+    """
+    perl5lib_paths = []
+    for path in [src.short_path for src in ctx.files.srcs]:
+        libdir_for_src = None
+        for libdir in ctx.attr.perl5lib_paths:
+            path_parts = path.split("/")
+            if libdir in path_parts:
+                libdir_for_src = "/".join(path_parts[:path_parts.index(libdir) + 1])
+                break
+        if not libdir_for_src:
+            libdir_for_src = (ctx.label.workspace_root or ".") + "/" + ctx.label.package
+        perl5lib_paths.append(libdir_for_src)
+    return depset(direct = perl5lib_paths).to_list()
+
 def _perl_library_implementation(ctx):
     transitive_sources = transitive_deps(ctx)
     return [
@@ -107,8 +134,15 @@ def _perl_library_implementation(ctx):
         ),
         PerlLibrary(
             transitive_perl_sources = transitive_sources.srcs,
+            perl5lib_paths = _perl5lib_paths(ctx),
         ),
     ]
+
+def sum(items, initial):
+    result = initial
+    for item in items:
+        result += item
+    return result
 
 def _perl_binary_implementation(ctx):
     toolchain = ctx.toolchains["@rules_perl//perl:toolchain_type"].perl_runtime
@@ -120,10 +154,14 @@ def _perl_binary_implementation(ctx):
     if main == None:
         main = _get_main_from_sources(ctx)
 
+    perl5lib_paths = sum([dep[PerlLibrary].perl5lib_paths for dep in ctx.attr.deps], [])
+    perl5lib_paths_str = ":" + ":".join(perl5lib_paths) if perl5lib_paths else ""
+
     ctx.actions.expand_template(
         template = ctx.file._wrapper_template,
         output = ctx.outputs.executable,
         substitutions = {
+            "{PERL5LIB}": perl5lib_paths_str,
             "{env_vars}": _env_vars(ctx),
             "{interpreter}": interpreter.short_path,
             "{main}": main.short_path,
@@ -273,6 +311,7 @@ perl_library = rule(
     attrs = {
         "data": _perl_data_attr,
         "deps": _perl_deps_attr,
+        "perl5lib_paths": attr.string_list(default = ["lib"]),
         "srcs": _perl_srcs_attr,
     },
     implementation = _perl_library_implementation,


### PR DESCRIPTION
The current advice for loading perl_libraries is to manually add a `PERL5LIB` env on perl_binary.
This only really works for perl_library dependencies in the same workspace and for external dependencies in WORKSPACE mode. In Bzlmod paths like `../fcgi/lib` can't be hard-coded (at least not when the repo isn't always _main but is a library itself).

This PR automates setting the PERL5LIB by means of a new `includes` attr on the perl_library rule.

This seems to work well in my (very limited) test environment.

(Note: I needed to comment out HAVE_DEV_PTMX to get the perl_xs to compile on my machine 🤷)