### PR TITLE
Set `PATH_PREFIX=./` instead of failing to bazel run a program with a perl_binary data dep

### DIFF
--- a/perl/binary_wrapper.tpl
+++ b/perl/binary_wrapper.tpl
@@ -7,8 +7,7 @@ elif [ -s `dirname $0`/../../MANIFEST ]; then
 elif [ -d $0.runfiles ]; then
   PATH_PREFIX=`cd $0.runfiles; pwd`/{workspace_name}/
 else
-  echo "WARNING: it does not look to be at the .runfiles directory" >&2
-  exit 1
+  PATH_PREFIX=./
 fi
 
 {env_vars} $PATH_PREFIX{interpreter} -I${PATH_PREFIX} ${PATH_PREFIX}{main} "$@"

--- a/test/data_dep/BUILD
+++ b/test/data_dep/BUILD
@@ -1,0 +1,35 @@
+genrule(
+    name = "gen_program_sh",
+    srcs = ["@genhtml//:genhtml_bin"],
+    outs = ["program.sh"],
+    cmd = """\
+cat <<"EOF" >$@
+#!/bin/bash
+set -euxo pipefail
+genhtml='$(rootpath @genhtml//:genhtml_bin)'
+test "$$("$$genhtml" --version)" == "genhtml: LCOV version 1.0"
+EOF
+""",
+)
+
+sh_binary(
+    name = "program_bin",
+    srcs = ["program.sh"],
+    data = ["@genhtml//:genhtml_bin"],
+)
+
+genrule(
+    name = "gen_program_test_sh",
+    srcs = [":program_bin"],
+    outs = ["program_test.sh"],
+    cmd = """\
+echo '#!/bin/sh' >$@
+echo 'exec env --ignore-environment test/data_dep/program_bin' >>$@
+""",
+)
+
+sh_test(
+    name = "program_test",
+    srcs = ["program_test.sh"],
+    data = [":program_bin"],
+)


### PR DESCRIPTION
I had the issue that the binary wrapper fails when it is a data dependency of some other program which is run under `bazel run` (it does work under `bazel test`!)
The issue is that during bazel run RUNFILES_DIR may not be set and the MANIFEST file may not exist at ../.. even if you did not cd somewhere else.
The correct thing to do for the wrapper in this case is to accept the interpreter short path and main short path as-is from the starlark side. We can just set PATH_PREFIX=./ for the same effect.

I added a test that is red without the binary_wrapper change and becomes green when the change is applied. The trick here is to use `env -i` to remove the test envs from the sh_test so it behaves more like a bazel run and not bazel test.

Note that I don't think the binary_wrapper should explicitly fail anyways. Rather it should just let things play out. Other things will fail in any case if paths are not set up correctly. And if things won't fail -- well then the wrapper shouldn't make them fail either :)