### PR TITLE
Fix runfiles creation on windows

### DIFF
--- a/perl/private/entrypoint.pl
+++ b/perl/private/entrypoint.pl
@@ -9,7 +9,7 @@ use Cwd 'abs_path';
 use JSON::PP;
 
 # Ensure enough args
-die "Usage: $0 <config.json> <main.pl> -- [args...]" unless @ARGV >= 3;
+die "Usage: $0 <config.json> <main.pl> -- [args...]\n" unless @ARGV >= 3;
 
 # Extract config path and main script path
 my $config_path = shift @ARGV;
@@ -18,14 +18,14 @@ my $main_path   = shift @ARGV;
 # Find `--` separator
 my $separator_index = 0;
 $separator_index++ until $separator_index >= @ARGV || $ARGV[$separator_index] eq '--';
-die "Missing -- separator after config and main script paths" if $separator_index == @ARGV;
+die "Missing -- separator after config and main script paths\n" if $separator_index == @ARGV;
 
 # Get args after --
 my @extra_args = @ARGV[ $separator_index + 1 .. $#ARGV ];
 splice(@ARGV, $separator_index);  # remove args after --
 
 # Load JSON config
-open my $fh, '<', $config_path or die "Can't open config file '$config_path': $!";
+open my $fh, '<', $config_path or die "Can't open config file '$config_path': $!\n";
 my $json_text = do { local $/; <$fh> };
 close $fh;
 
@@ -46,18 +46,22 @@ unless (defined $runfiles) {
     $ENV{RUNFILES_DIR} = $runfiles;
 
     # Copy entries from manifest
-    open my $mfh, '<', $manifest or die "Failed to open manifest file '$manifest': $!";
+    open my $mfh, '<', $manifest or die "Failed to open manifest file '$manifest': $!\n";
     while (my $line = <$mfh>) {
         chomp $line;
-        next if $line =~ /^\s*$/;  # skip blank lines
+
+        # skip blank lines
+        next if $line =~ /^\s*$/;
 
         my ($rel_path, $real_path) = split ' ', $line, 2;
-        die "Invalid manifest line: $line" unless defined $real_path;
+
+        # Skip any lines which don't cleanly split into key value pairs.
+        next unless defined $real_path && length $real_path;
 
         my $dst_path = File::Spec->catfile($runfiles, $rel_path);
         make_path(dirname($dst_path));
         copy($real_path, $dst_path)
-            or die "Failed to copy '$real_path' to '$dst_path': $!";
+            or die "Failed to copy '$real_path' to '$dst_path': $!\n";
     }
     close $mfh;
 }


### PR DESCRIPTION
This fixes an error in environments that rely on `RUNFILES_MANIFEST_FILE` (e.g. Windows) where lines that were not key-value pairs would cause runfiles to break.