### PR TITLE
Add `@rules_perl//perl:current_exec_toolchain`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,18 +12,11 @@ exports_files([
     )
     for name in [
         "current_toolchain",
-        "current_target_toolchain",
-        "target_toolchain_type",
         "perl_darwin_amd64_toolchain",
         "perl_darwin_arm64_toolchain",
         "perl_linux_amd64_toolchain",
         "perl_linux_arm64_toolchain",
         "perl_windows_x86_64_toolchain",
-        "perl_darwin_amd64_target_toolchain",
-        "perl_darwin_arm64_target_toolchain",
-        "perl_linux_amd64_target_toolchain",
-        "perl_linux_arm64_target_toolchain",
-        "perl_windows_x86_64_target_toolchain",
         "toolchain_type",
     ]
 ]

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,7 @@
+# Migrating
+
+## 1.0
+
+In 1.0, `@rules_perl//perl:toolchain_type` (and `@rules_perl//perl:current_toolchain`) represent the **target** (runtime) toolchain, so that `perl_binary` and cross-compilation use the correct interpreter for the target platform.
+
+Rules that consume toolchains for actions (e.g. custom rules that run Perl during the build) should depend on `@rules_perl//perl:exec_toolchain_type` (or `@rules_perl//perl:current_exec_toolchain`).

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,11 +28,6 @@ register_toolchains(
     "@rules_perl//perl:perl_linux_amd64_toolchain",
     "@rules_perl//perl:perl_linux_arm64_toolchain",
     "@rules_perl//perl:perl_windows_x86_64_toolchain",
-    "@rules_perl//perl:perl_darwin_arm64_target_toolchain",
-    "@rules_perl//perl:perl_darwin_amd64_target_toolchain",
-    "@rules_perl//perl:perl_linux_amd64_target_toolchain",
-    "@rules_perl//perl:perl_linux_arm64_target_toolchain",
-    "@rules_perl//perl:perl_windows_x86_64_target_toolchain",
 )
 
 cpan = use_extension("@rules_perl//perl/cpan:extensions.bzl", "cpan")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,10 +23,15 @@ use_repo(
 )
 
 register_toolchains(
-    "@rules_perl//perl:perl_darwin_arm64_toolchain",
+    "@rules_perl//perl:perl_darwin_amd64_toolchain_exec",
     "@rules_perl//perl:perl_darwin_amd64_toolchain",
+    "@rules_perl//perl:perl_darwin_arm64_toolchain_exec",
+    "@rules_perl//perl:perl_darwin_arm64_toolchain",
+    "@rules_perl//perl:perl_linux_amd64_toolchain_exec",
     "@rules_perl//perl:perl_linux_amd64_toolchain",
+    "@rules_perl//perl:perl_linux_arm64_toolchain_exec",
     "@rules_perl//perl:perl_linux_arm64_toolchain",
+    "@rules_perl//perl:perl_windows_x86_64_toolchain_exec",
     "@rules_perl//perl:perl_windows_x86_64_toolchain",
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -18,10 +18,6 @@ perl_register_toolchains()
             cpu = platform.cpu,
             os = platform.os,
         ),
-        "@rules_perl//perl:perl_{os}_{cpu}_target_toolchain".format(
-            cpu = platform.cpu,
-            os = platform.os,
-        ),
     )
     for platform in PLATFORMS
 ]

--- a/perl/BUILD.bazel
+++ b/perl/BUILD.bazel
@@ -40,7 +40,7 @@ toolchain_type(
                 cpu = platform.cpu,
                 os = platform.os,
             ),
-            exec_compatible_with = platform.exec_compatible_with,
+            target_compatible_with = platform.target_compatible_with,
             toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
                 cpu = platform.cpu,
                 os = platform.os,

--- a/perl/BUILD.bazel
+++ b/perl/BUILD.bazel
@@ -1,5 +1,5 @@
 load(":platforms.bzl", "PLATFORMS")
-load(":toolchain.bzl", "current_perl_target_toolchain", "current_perl_toolchain", "perl_toolchain")
+load(":toolchain.bzl", "current_perl_toolchain", "perl_toolchain")
 
 alias(
     name = "binary_wrapper.tpl",
@@ -7,18 +7,12 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-# toolchain_type is the execution-platform toolchain type. Rules that only need Perl at build time
-# (perl_xs, genrule, etc.) resolve this toolchain based on the *execution* platform.
+# toolchain_type defines a name for a kind of toolchain. Our toolchains
+# declare that they have this type. Our rules request a toolchain of this type.
+# Bazel selects a toolchain of the correct type that satisfies platform
+# constraints from among registered toolchains.
 toolchain_type(
     name = "toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
-# target_toolchain_type is the target-platform toolchain type. Rules that bundle a Perl interpreter
-# into the final output (perl_binary, perl_test) resolve this toolchain based on the *target*
-# platform so that the correct interpreter is included for the platform the binary will run on.
-toolchain_type(
-    name = "target_toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -38,14 +32,15 @@ toolchain_type(
             visibility = ["//visibility:public"],
         ),
 
-        # Exec toolchain: resolved based on exec platform constraints.
-        # Used by build-time rules (perl_xs, genrule, etc.).
+        # toolchain is a Bazel toolchain that expresses execution and target
+        # constraints for toolchain_impl. This target should be registered by
+        # calling register_toolchains in a WORKSPACE file.
         toolchain(
             name = "perl_{os}_{cpu}_toolchain".format(
                 cpu = platform.cpu,
                 os = platform.os,
             ),
-            exec_compatible_with = platform.compatible_with,
+            exec_compatible_with = platform.exec_compatible_with,
             toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
                 cpu = platform.cpu,
                 os = platform.os,
@@ -53,40 +48,17 @@ toolchain_type(
             toolchain_type = ":toolchain_type",
             visibility = ["//visibility:public"],
         ),
-
-        # Target toolchain: resolved based on target platform constraints.
-        # Used by perl_binary / perl_test to bundle the correct interpreter
-        # for the platform the binary will run on.
-        toolchain(
-            name = "perl_{os}_{cpu}_target_toolchain".format(
-                cpu = platform.cpu,
-                os = platform.os,
-            ),
-            target_compatible_with = platform.compatible_with,
-            toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
-                cpu = platform.cpu,
-                os = platform.os,
-            ),
-            toolchain_type = ":target_toolchain_type",
-            visibility = ["//visibility:public"],
-        ),
     )
     for platform in PLATFORMS
 ]
 
-# This rule exists so that the current exec perl toolchain can be used in the `toolchains` attribute
-# of other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution
-# has happened, to a rule which expects a concrete implementation of a toolchain, rather than a
+# This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
+# other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has
+# happened, to a rule which expects a concrete implementation of a toolchain, rather than a
 # toolchain_type which could be resolved to that toolchain.
 #
 # See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
 current_perl_toolchain(
     name = "current_toolchain",
-    visibility = ["//visibility:public"],
-)
-
-# Same as current_toolchain but resolves based on the target platform.
-current_perl_target_toolchain(
-    name = "current_target_toolchain",
     visibility = ["//visibility:public"],
 )

--- a/perl/BUILD.bazel
+++ b/perl/BUILD.bazel
@@ -1,5 +1,5 @@
 load(":platforms.bzl", "PLATFORMS")
-load(":toolchain.bzl", "current_perl_toolchain", "perl_toolchain")
+load(":toolchain.bzl", "current_exec_perl_toolchain", "current_perl_toolchain", "perl_toolchain")
 
 alias(
     name = "binary_wrapper.tpl",
@@ -60,5 +60,10 @@ toolchain_type(
 # See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
 current_perl_toolchain(
     name = "current_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+current_exec_perl_toolchain(
+    name = "current_exec_toolchain",
     visibility = ["//visibility:public"],
 )

--- a/perl/BUILD.bazel
+++ b/perl/BUILD.bazel
@@ -16,6 +16,11 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
+toolchain_type(
+    name = "exec_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 [
     (
         # toolchain_impl gathers information about the Perl toolchain.
@@ -46,6 +51,19 @@ toolchain_type(
                 os = platform.os,
             ),
             toolchain_type = ":toolchain_type",
+            visibility = ["//visibility:public"],
+        ),
+        toolchain(
+            name = "perl_{os}_{cpu}_toolchain_exec".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            ),
+            exec_compatible_with = platform.target_compatible_with,
+            toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            ),
+            toolchain_type = ":exec_toolchain_type",
             visibility = ["//visibility:public"],
         ),
     )

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -27,10 +27,6 @@ def perl_register_toolchains():
                 os = platform.os,
                 cpu = platform.cpu,
             ),
-            "@rules_perl//perl:perl_{os}_{cpu}_target_toolchain".format(
-                os = platform.os,
-                cpu = platform.cpu,
-            ),
         )
 
 def perl_rules_dependencies():

--- a/perl/platforms.bzl
+++ b/perl/platforms.bzl
@@ -10,7 +10,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-arm64.tar.xz".format(UNIX_VERSION)],
         sha256 = "e58b98338bc52f352dc95310363ab6c725897557512b90b593c70ea357f1b2ab",
         strip_prefix = "perl-darwin-arm64",
-        compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
@@ -21,7 +21,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-amd64.tar.xz".format(UNIX_VERSION)],
         sha256 = "6e16d12f6a765cbb708ebcb6fe9c74f0d71e1d648bff0ff7b8d88134e54b736a",
         strip_prefix = "perl-darwin-amd64",
-        compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
@@ -32,7 +32,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-amd64.tar.xz".format(UNIX_VERSION)],
         sha256 = "cd3216bd72fa4fe3b76fc7f4e2f1004d75e42495d515c09b53d79cba3700dd7b",
         strip_prefix = "perl-linux-amd64",
-        compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
@@ -43,7 +43,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-arm64.tar.xz".format(UNIX_VERSION)],
         sha256 = "01b3beb5e5f806a5447e42246b440e54a96c314284a68be89ff2b980ba4a4ec1",
         strip_prefix = "perl-linux-arm64",
-        compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:arm64",
         ],
@@ -57,7 +57,7 @@ PLATFORMS = [
         ],
         sha256 = "754f3e2a8e473dc68d1540c7802fb166a025f35ef18960c4564a31f8b5933907",
         strip_prefix = "",
-        compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],

--- a/perl/platforms.bzl
+++ b/perl/platforms.bzl
@@ -10,7 +10,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-arm64.tar.xz".format(UNIX_VERSION)],
         sha256 = "e58b98338bc52f352dc95310363ab6c725897557512b90b593c70ea357f1b2ab",
         strip_prefix = "perl-darwin-arm64",
-        exec_compatible_with = [
+        target_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
@@ -21,7 +21,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-amd64.tar.xz".format(UNIX_VERSION)],
         sha256 = "6e16d12f6a765cbb708ebcb6fe9c74f0d71e1d648bff0ff7b8d88134e54b736a",
         strip_prefix = "perl-darwin-amd64",
-        exec_compatible_with = [
+        target_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
@@ -32,7 +32,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-amd64.tar.xz".format(UNIX_VERSION)],
         sha256 = "cd3216bd72fa4fe3b76fc7f4e2f1004d75e42495d515c09b53d79cba3700dd7b",
         strip_prefix = "perl-linux-amd64",
-        exec_compatible_with = [
+        target_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
@@ -43,7 +43,7 @@ PLATFORMS = [
         urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-arm64.tar.xz".format(UNIX_VERSION)],
         sha256 = "01b3beb5e5f806a5447e42246b440e54a96c314284a68be89ff2b980ba4a4ec1",
         strip_prefix = "perl-linux-arm64",
-        exec_compatible_with = [
+        target_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:arm64",
         ],
@@ -57,7 +57,7 @@ PLATFORMS = [
         ],
         sha256 = "754f3e2a8e473dc68d1540c7802fb166a025f35ef18960c4564a31f8b5933907",
         strip_prefix = "",
-        exec_compatible_with = [
+        target_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],

--- a/perl/private/perl.bzl
+++ b/perl/private/perl.bzl
@@ -151,6 +151,7 @@ def _perl_library_implementation(ctx):
 perl_library = rule(
     attrs = _LIBRARY_PERL_ATTRS,
     implementation = _perl_library_implementation,
+    toolchains = ["@rules_perl//perl:toolchain_type"],
 )
 
 def _get_main_from_sources(ctx):
@@ -172,7 +173,7 @@ def _rlocationpath(file, workspace_name):
     return "{}/{}".format(workspace_name, file.short_path)
 
 def _perl_binary_implementation(ctx):
-    toolchain = ctx.toolchains["@rules_perl//perl:target_toolchain_type"].perl_runtime
+    toolchain = ctx.toolchains["@rules_perl//perl:toolchain_type"].perl_runtime
     interpreter = toolchain.interpreter
 
     main = ctx.file.main
@@ -245,7 +246,7 @@ perl_binary = rule(
     attrs = _EXECUTABLE_PERL_ATTRS,
     executable = True,
     implementation = _perl_binary_implementation,
-    toolchains = ["@rules_perl//perl:target_toolchain_type"],
+    toolchains = ["@rules_perl//perl:toolchain_type"],
 )
 
 perl_test = rule(
@@ -253,5 +254,5 @@ perl_test = rule(
     executable = True,
     test = True,
     implementation = _perl_test_implementation,
-    toolchains = ["@rules_perl//perl:target_toolchain_type"],
+    toolchains = ["@rules_perl//perl:toolchain_type"],
 )

--- a/perl/private/perl.bzl
+++ b/perl/private/perl.bzl
@@ -151,7 +151,6 @@ def _perl_library_implementation(ctx):
 perl_library = rule(
     attrs = _LIBRARY_PERL_ATTRS,
     implementation = _perl_library_implementation,
-    toolchains = ["@rules_perl//perl:toolchain_type"],
 )
 
 def _get_main_from_sources(ctx):

--- a/perl/private/perl_xs.bzl
+++ b/perl/private/perl_xs.bzl
@@ -66,7 +66,8 @@ def _perl_xs_cc_lib(ctx, toolchain, srcs):
 
 def _perl_xs_implementation(ctx):
     toolchain = ctx.toolchains["@rules_perl//perl:toolchain_type"].perl_runtime
-    xsubpp = toolchain.xsubpp
+    exec_toolchain = ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime
+    xsubpp = exec_toolchain.xsubpp
 
     toolchain_files = toolchain.runtime
 
@@ -109,11 +110,17 @@ def _perl_xs_implementation(ctx):
     else:
         output = ctx.actions.declare_file(ctx.label.name + ".so")
 
-    ctx.actions.run_shell(
+    ctx.actions.run(
         outputs = [output],
         inputs = [dyn_lib],
-        arguments = [dyn_lib.path, output.path],
-        command = "cp $1 $2",
+        executable = exec_toolchain.interpreter,
+        arguments = [
+            "-e",
+            "use File::Copy qw(copy); copy($ARGV[0], $ARGV[1]) or die $!;",
+            dyn_lib.path,
+            output.path,
+        ],
+        mnemonic = "PerlCopySo",
     )
 
     return [
@@ -161,8 +168,9 @@ perl_xs = rule(
             doc = "Typemap files used by xsubpp when translating XS. Paths are resolved relative to each .xs file's directory.",
             allow_files = True,
         ),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        "_perl_toolchain": attr.label(
+            cfg = "exec",
+            default = Label("//perl:current_toolchain"),
         ),
     },
     implementation = _perl_xs_implementation,

--- a/perl/private/perl_xs.bzl
+++ b/perl/private/perl_xs.bzl
@@ -87,6 +87,7 @@ def _perl_xs_implementation(ctx):
             args_typemaps_relative += ["-typemap", relative_typemap_path]
 
         ctx.actions.run(
+            mnemonic = "PerlTranslitterate",
             outputs = [out],
             inputs = [src] + ctx.files.typemaps,
             arguments = args_typemaps_relative + ["-output", out.path, src.path],
@@ -121,17 +122,48 @@ def _perl_xs_implementation(ctx):
     ]
 
 perl_xs = rule(
+    doc = """Builds a Perl XS extension as a shared library (.so).
+
+    Translates `.xs` sources to C via xsubpp, compiles and links them (with optional
+    extra C/C++ sources and typemaps), and produces a single shared library suitable
+    for loading with `DynaLoader` / `use` from Perl.
+    """,
     attrs = {
-        "cc_srcs": attr.label_list(allow_files = [".c", ".cc"]),
-        "copts": attr.string_list(),
-        "defines": attr.string_list(),
-        "deps": attr.label_list(providers = [CcInfo]),
-        "linkopts": attr.string_list(),
-        "output_loc": attr.string(),
-        "srcs": attr.label_list(allow_files = [".xs"]),
-        "textual_hdrs": attr.label_list(allow_files = True),
-        "typemaps": attr.label_list(allow_files = True),
-        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+        "cc_srcs": attr.label_list(
+            doc = "Additional C or C++ source files compiled and linked into the extension.",
+            allow_files = [".c", ".cc"],
+        ),
+        "copts": attr.string_list(
+            doc = "Extra compiler flags passed to the C/C++ compilation.",
+        ),
+        "defines": attr.string_list(
+            doc = "Preprocessor defines (e.g. -DNAME or -DNAME=value) for compilation.",
+        ),
+        "deps": attr.label_list(
+            doc = "Targets providing CcInfo (e.g. cc_library) to link with the extension.",
+            providers = [CcInfo],
+        ),
+        "linkopts": attr.string_list(
+            doc = "Extra linker flags passed when linking the shared library.",
+        ),
+        "output_loc": attr.string(
+            doc = "Optional output path for the shared library. If empty, defaults to <target_name>.so.",
+        ),
+        "srcs": attr.label_list(
+            doc = "Perl XS (.xs) source files. Each is translated to C by xsubpp and then compiled.",
+            allow_files = [".xs"],
+        ),
+        "textual_hdrs": attr.label_list(
+            doc = "Header files included in the build. Their directories are added to the include path.",
+            allow_files = True,
+        ),
+        "typemaps": attr.label_list(
+            doc = "Typemap files used by xsubpp when translating XS. Paths are resolved relative to each .xs file's directory.",
+            allow_files = True,
+        ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
     },
     implementation = _perl_xs_implementation,
     fragments = ["cpp"],

--- a/perl/private/perl_xs.bzl
+++ b/perl/private/perl_xs.bzl
@@ -66,7 +66,7 @@ def _perl_xs_cc_lib(ctx, toolchain, srcs):
 
 def _perl_xs_implementation(ctx):
     toolchain = ctx.toolchains["@rules_perl//perl:toolchain_type"].perl_runtime
-    exec_toolchain = ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime
+    exec_toolchain = ctx.toolchains["@rules_perl//perl:exec_toolchain_type"].perl_runtime
     xsubpp = exec_toolchain.xsubpp
 
     toolchain_files = toolchain.runtime
@@ -168,14 +168,11 @@ perl_xs = rule(
             doc = "Typemap files used by xsubpp when translating XS. Paths are resolved relative to each .xs file's directory.",
             allow_files = True,
         ),
-        "_perl_toolchain": attr.label(
-            cfg = "exec",
-            default = Label("//perl:current_toolchain"),
-        ),
     },
     implementation = _perl_xs_implementation,
     fragments = ["cpp"],
     toolchains = [
+        "@rules_perl//perl:exec_toolchain_type",
         "@rules_perl//perl:toolchain_type",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],

--- a/perl/toolchain.bzl
+++ b/perl/toolchain.bzl
@@ -113,13 +113,41 @@ def _current_perl_toolchain_impl(ctx):
         ),
     ]
 
-# This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
-# other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has
-# happened, to a rule which expects a concrete implementation of a toolchain, rather than a
-# toochain_type which could be resolved to that toolchain.
-#
-# See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
 current_perl_toolchain = rule(
+    doc = """\
+This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
+other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has
+happened, to a rule which expects a concrete implementation of a toolchain, rather than a
+toochain_type which could be resolved to that toolchain.
+
+See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
+""",
     implementation = _current_perl_toolchain_impl,
     toolchains = ["@rules_perl//perl:toolchain_type"],
+)
+
+def _current_exec_perl_toolchain_impl(ctx):
+    toolchain = ctx.attr._current_perl_toolchain[platform_common.ToolchainInfo]
+
+    return [
+        toolchain,
+        toolchain.make_variables,
+        DefaultInfo(
+            runfiles = ctx.runfiles(
+                [],
+                transitive_files = toolchain.perl_runtime.runtime,
+            ),
+            files = toolchain.perl_runtime.runtime,
+        ),
+    ]
+
+current_exec_perl_toolchain = rule(
+    doc = "Similar to `current_perl_toolchain` but always provides the toolchain for the exec configuration.",
+    implementation = _current_exec_perl_toolchain_impl,
+    attrs = {
+        "_current_perl_toolchain": attr.label(
+            cfg = "exec",
+            default = Label("//perl:current_toolchain"),
+        ),
+    },
 )

--- a/perl/toolchain.bzl
+++ b/perl/toolchain.bzl
@@ -127,7 +127,7 @@ See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
 )
 
 def _current_exec_perl_toolchain_impl(ctx):
-    toolchain = ctx.attr._current_perl_toolchain[platform_common.ToolchainInfo]
+    toolchain = ctx.toolchains["@rules_perl//perl:exec_toolchain_type"]
 
     return [
         toolchain,
@@ -144,10 +144,5 @@ def _current_exec_perl_toolchain_impl(ctx):
 current_exec_perl_toolchain = rule(
     doc = "Similar to `current_perl_toolchain` but always provides the toolchain for the exec configuration.",
     implementation = _current_exec_perl_toolchain_impl,
-    attrs = {
-        "_current_perl_toolchain": attr.label(
-            cfg = "exec",
-            default = Label("//perl:current_toolchain"),
-        ),
-    },
+    toolchains = ["@rules_perl//perl:exec_toolchain_type"],
 )

--- a/perl/toolchain.bzl
+++ b/perl/toolchain.bzl
@@ -113,34 +113,13 @@ def _current_perl_toolchain_impl(ctx):
         ),
     ]
 
-# This rule exists so that the current exec perl toolchain can be used in the `toolchains` attribute
-# of other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution
-# has happened, to a rule which expects a concrete implementation of a toolchain, rather than a
-# toolchain_type which could be resolved to that toolchain.
+# This rule exists so that the current perl toolchain can be used in the `toolchains` attribute of
+# other rules, such as genrule. It allows exposing a perl_toolchain after toolchain resolution has
+# happened, to a rule which expects a concrete implementation of a toolchain, rather than a
+# toochain_type which could be resolved to that toolchain.
 #
 # See https://github.com/bazelbuild/bazel/issues/14009#issuecomment-921960766
 current_perl_toolchain = rule(
     implementation = _current_perl_toolchain_impl,
     toolchains = ["@rules_perl//perl:toolchain_type"],
-)
-
-def _current_perl_target_toolchain_impl(ctx):
-    toolchain = ctx.toolchains["@rules_perl//perl:target_toolchain_type"]
-
-    return [
-        toolchain,
-        toolchain.make_variables,
-        DefaultInfo(
-            runfiles = ctx.runfiles(
-                [],
-                transitive_files = toolchain.perl_runtime.runtime,
-            ),
-            files = toolchain.perl_runtime.runtime,
-        ),
-    ]
-
-# Same as current_perl_toolchain but resolves based on the target platform.
-current_perl_target_toolchain = rule(
-    implementation = _current_perl_target_toolchain_impl,
-    toolchains = ["@rules_perl//perl:target_toolchain_type"],
 )


### PR DESCRIPTION
This change adds a variant of `current_perl_toolchain` that provides an interpreter for exec platforms. This is useful in cases where toolchains are passed to rules that intend to invoke perl within an action. E.g.

```python
    genrule(
        name = "gen",
        srcs = [
            "src.pl",
        ],
        outs = ["out.txt"],
        cmd = "$(PERL) $(execpath src.pl) $@",
        cmd_bat = "$(PERL) $(execpath src.pl) $@",
        toolchains = ["@rules_perl//perl:current_exec_toolchain"],
    )
```