### PR TITLE
Register host-fallback perl toolchains so build-time perl_binary tools resolve for any target platform

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,6 +33,13 @@ register_toolchains(
     "@rules_perl//perl:perl_linux_arm64_toolchain",
     "@rules_perl//perl:perl_windows_x86_64_toolchain_exec",
     "@rules_perl//perl:perl_windows_x86_64_toolchain",
+    # Host-fallback toolchains are registered last so they only resolve when no
+    # target-constrained perl toolchain above matches the target platform.
+    "@rules_perl//perl:perl_darwin_amd64_toolchain_any_target",
+    "@rules_perl//perl:perl_darwin_arm64_toolchain_any_target",
+    "@rules_perl//perl:perl_linux_amd64_toolchain_any_target",
+    "@rules_perl//perl:perl_linux_arm64_toolchain_any_target",
+    "@rules_perl//perl:perl_windows_x86_64_toolchain_any_target",
 )
 
 cpan = use_extension("@rules_perl//perl/cpan:extensions.bzl", "cpan")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ Perl rules
 
 module(
     name = "rules_perl",
-    version = "1.1.1",
+    version = "1.1.2",
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -129,8 +129,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -191,7 +191,7 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -248,7 +248,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/perl/BUILD.bazel
+++ b/perl/BUILD.bazel
@@ -66,6 +66,28 @@ toolchain_type(
             toolchain_type = ":exec_toolchain_type",
             visibility = ["//visibility:public"],
         ),
+
+        # Host-fallback toolchain: constrained on the execution platform only,
+        # with no target constraint. When these are registered after the
+        # target-constrained toolchains above, a native perl still wins whenever
+        # the target platform has one. But a perl_binary used purely as a
+        # build-time tool (for example lcov's report generators) still resolves
+        # against the host perl when the target platform has no native perl,
+        # such as an embedded or RTOS cross-compile. This restores the pre-1.0
+        # behaviour where perl toolchains carried no target constraint.
+        toolchain(
+            name = "perl_{os}_{cpu}_toolchain_any_target".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            ),
+            exec_compatible_with = platform.target_compatible_with,
+            toolchain = ":perl_{os}_{cpu}_toolchain_impl".format(
+                cpu = platform.cpu,
+                os = platform.os,
+            ),
+            toolchain_type = ":toolchain_type",
+            visibility = ["//visibility:public"],
+        ),
     )
     for platform in PLATFORMS
 ]

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -29,6 +29,16 @@ def perl_register_toolchains():
             ),
         )
 
+    # Host-fallback toolchains are registered last so they only resolve when no
+    # target-constrained perl toolchain above matches the target platform.
+    for platform in PLATFORMS:
+        native.register_toolchains(
+            "@rules_perl//perl:perl_{os}_{cpu}_toolchain_any_target".format(
+                os = platform.os,
+                cpu = platform.cpu,
+            ),
+        )
+
 def perl_rules_dependencies():
     """Declares external repositories that rules_perl depends on.
 

--- a/test/toolchain_resolution/BUILD.bazel
+++ b/test/toolchain_resolution/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//perl:perl.bzl", "perl_binary")
+load(":transition.bzl", "build_under_platform")
+
+# A target platform with no native perl toolchain (there is no perl runtime for
+# linux/s390x). Before the host-fallback toolchains were registered, resolving a
+# perl_binary for this platform failed with "No matching toolchains found".
+platform(
+    name = "perlless",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:s390x",
+    ],
+)
+
+perl_binary(
+    name = "tool",
+    srcs = ["tool.pl"],
+    tags = ["manual"],
+)
+
+build_under_platform(
+    name = "tool_on_perlless",
+    platform = ":perlless",
+    tags = ["manual"],
+    target = ":tool",
+)
+
+# Regression test: a perl_binary used as a build tool must still resolve a perl
+# toolchain (the host fallback) when cross-compiling to a perl-less platform.
+build_test(
+    name = "perlless_toolchain_resolution_test",
+    targets = [":tool_on_perlless"],
+)

--- a/test/toolchain_resolution/BUILD.bazel
+++ b/test/toolchain_resolution/BUILD.bazel
@@ -2,8 +2,8 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//perl:perl.bzl", "perl_binary")
 load(":transition.bzl", "build_under_platform")
 
-# A target platform with no native perl toolchain (there is no perl runtime for
-# linux/s390x). Before the host-fallback toolchains were registered, resolving a
+# A target platform with no native perl toolchain provided by rules_perl for
+# linux/s390x. Before the host-fallback toolchains were registered, resolving a
 # perl_binary for this platform failed with "No matching toolchains found".
 platform(
     name = "perlless",

--- a/test/toolchain_resolution/tool.pl
+++ b/test/toolchain_resolution/tool.pl
@@ -1,0 +1,2 @@
+# A perl_binary used purely as a build-time tool.
+print "ok\n";

--- a/test/toolchain_resolution/transition.bzl
+++ b/test/toolchain_resolution/transition.bzl
@@ -2,7 +2,7 @@
 platform that has no native perl toolchain."""
 
 def _platform_transition_impl(_settings, attr):
-    return {"//command_line_option:platforms": str(attr.platform)}
+    return {"//command_line_option:platforms": [str(attr.platform)]}
 
 _platform_transition = transition(
     implementation = _platform_transition_impl,

--- a/test/toolchain_resolution/transition.bzl
+++ b/test/toolchain_resolution/transition.bzl
@@ -1,0 +1,26 @@
+"""A platform transition used to exercise perl toolchain resolution for a target
+platform that has no native perl toolchain."""
+
+def _platform_transition_impl(_settings, attr):
+    return {"//command_line_option:platforms": str(attr.platform)}
+
+_platform_transition = transition(
+    implementation = _platform_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _build_under_platform_impl(ctx):
+    return [DefaultInfo(files = depset(ctx.files.target))]
+
+build_under_platform = rule(
+    doc = "Builds `target` under `platform` so its toolchain resolution is exercised.",
+    implementation = _build_under_platform_impl,
+    attrs = {
+        "platform": attr.label(mandatory = True),
+        "target": attr.label(cfg = _platform_transition, mandatory = True),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """rules_perl version"""
 
-VERSION = "1.1.1"
+VERSION = "1.1.2"


### PR DESCRIPTION
## Problem

`perl_binary`/`perl_test` resolve `@rules_perl//perl:toolchain_type` in the **target** configuration. Since the exec/target toolchain split, every registered toolchain of that type carries a `target_compatible_with`, so a `perl_binary` that is used purely as a **build-time tool** can no longer resolve a perl toolchain when cross-compiling to a target platform that has no native perl (e.g. QNX, or an embedded RTOS).

A concrete downstream example is the BCR [`lcov`](https://registry.bazel.build/modules/lcov) module, whose report generators are `perl_binary` targets. Pulling them into a coverage build for a non-host target platform fails at analysis:

```
ERROR: external/lcov+/BUILD:14:16: While resolving toolchains for target @@lcov+//:lcov:
       No matching toolchains found for types:
       @rules_perl//perl:toolchain_type
```

Before the toolchain split, the perl toolchains carried no target constraint, so this worked for any target platform.

## Fix

Register a **host-fallback** toolchain per host platform, constrained on the execution platform only (`exec_compatible_with = <host>`, no `target_compatible_with`), **after** the existing target-constrained toolchains.

Because Bazel picks the first matching registered toolchain:

- a native-target perl still wins whenever the target platform has one (no behavior change for supported targets), and
- a host-tool `perl_binary` falls back to the host perl for perl-less target platforms.

Registered in both bzlmod (`MODULE.bazel`) and WORKSPACE (`perl/deps.bzl`) paths.

## Test

Adds `test/toolchain_resolution/`, which cross-compiles a `perl_binary` to a perl-less `linux/s390x` platform via a platform transition and asserts it builds. The test fails without this change (`No matching toolchains found`) and passes with it.

## Notes

- Adds no new dependencies; `MODULE.bazel.lock` is unchanged.
- I'll sign the Google individual CLA.